### PR TITLE
allow for nested opts parameter in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function searchStream (query, opts = {}) {
     quality: 0.65,
     popularity: 0.98,
     maintenance: 0.5,
+    ...opts.opts, // this is to support the cli's --searchopts parameter
     ...opts
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -64,6 +64,35 @@ test('basic test', t => {
   })
 })
 
+test('basic test supports nested options', t => {
+  const query = qs.stringify({
+    text: 'oo',
+    size: 20,
+    from: 1,
+    quality: 0.65,
+    popularity: 0.98,
+    maintenance: 0.5
+  })
+  tnock(t, REG).get(`/-/v1/search?${query}`).once().reply(200, {
+    objects: [
+      { package: { name: 'cool', version: '1.0.0' } },
+      { package: { name: 'foo', version: '2.0.0' } }
+    ]
+  })
+
+  // this test is to ensure we don't break the nested opts parameter
+  // that the cli supplies when a user passes --searchopts=
+  return search('oo', { ...OPTS, opts: { from: 1 } }).then(results => {
+    t.similar(results, [{
+      name: 'cool',
+      version: '1.0.0'
+    }, {
+      name: 'foo',
+      version: '2.0.0'
+    }], 'got back an array of search results')
+  })
+})
+
 test('search.stream', t => {
   const query = qs.stringify({
     text: 'oo',


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

this is because the cli sends these options nested under a second `opts` parameter, so we need to also flatten that into our options here to allow for things like `--searchopts=from=2`

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
